### PR TITLE
Add facebookConnectPlugin variable for browser

### DIFF
--- a/www/facebook-browser.js
+++ b/www/facebook-browser.js
@@ -102,7 +102,7 @@ facebookConnectPlugin.browserInit = function (appId, version, s) {
   // Global :(
   // This function will be called by the FB SDK when the client is inited
   window.fbAsyncInit = function fbAsyncInit () {
-    version = version || 'v2.4'
+    version = version || 'v2.6'
 
     FB.init({
       appId: appId,


### PR DESCRIPTION
Current build of the Facebook plugin doesn't work in the browser as the facebookConnectPlugin variable is missing.

I have changed the browser version to export facebookConnectPlugin variable.
